### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/aofl-js-packages/object-utils/modules/core.js
+++ b/aofl-js-packages/object-utils/modules/core.js
@@ -12,7 +12,7 @@
  * @memberof module:@aofl/object-utils
  *
  * @param {Object} obj
- * @param {String} path dot notatino
+ * @param {String} path dot notation
  * @param {Function} op operation to perform as object is recursed by path.
  */
 const recurseObjectByPath = (obj, path, op) => {
@@ -25,11 +25,22 @@ const recurseObjectByPath = (obj, path, op) => {
       key = argPathParts[0];
       subPath = argPathParts.slice(1);
     }
+    if (isPrototypePolluted(key))
+      return;
     return op(key, subPath, source, recurse);
   };
 
   return recurse(pathParts, obj);
 };
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * 
+ * @memberof module:@aofl/object-utils
+ * 
+ * @param {String} key object key to check
+ */
+const isPrototypePolluted = (key) => /__proto__|constructor|prototype/.test(key);
 
 export {
   recurseObjectByPath

--- a/aofl-js-packages/object-utils/test/set.spec.js
+++ b/aofl-js-packages/object-utils/test/set.spec.js
@@ -44,4 +44,9 @@ describe('object-utils#set', function() {
     expect(set(this.data, 'noprop.noprop.noprop', 'noprop'));
     expect(get(this.data, 'noprop.noprop.noprop')).to.equal('noprop');
   });
+
+  it('Should not pollute object prototype', function() {
+    set(this.data, '__proto__.polluted', true);
+    expect({}.polluted).to.equal(undefined);
+  });
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`@aofl/object-utils` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40aofl%2Fobject-utils

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Use this sandbox: https://codesandbox.io/s/object-utils-prototype-pollution-qnxwg
2. Check the console:
```
Before : undefined
After : Prototype Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105568074-b5004400-5d5c-11eb-83c9-69cc11972b10.png)

To test the fix, I've included a PoC project with my patched fork and full dependencies installed. Download from [here](https://drive.google.com/file/d/1HKP2biEJ8_r5mkGuTVet6KUGgZEZ8c04/view?usp=sharing). Extract it and from the base directory, run `npm start`. Now visit the development server URL and check developer console.

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
