### PR TITLE
fix prototype pollution

### DIFF
--- a/aofl-js-packages/object-utils/modules/set.js
+++ b/aofl-js-packages/object-utils/modules/set.js
@@ -20,7 +20,7 @@ const set = (obj, path, val) => {
       source = defineProperty(source, key, val);
       return;
     }
-    if (!source?.hasOwnProperty('undefined')) {
+    if (!source?.hasOwnProperty(key)) {
       source = defineProperty(source, key, {});
     }
     return recurse(pathParts, source[key]);

--- a/aofl-js-packages/object-utils/modules/set.js
+++ b/aofl-js-packages/object-utils/modules/set.js
@@ -17,7 +17,7 @@ import {recurseObjectByPath} from './core';
 const set = (obj, path, val) => {
   return recurseObjectByPath(obj, path, (key, pathParts, source, recurse) => {
     if (pathParts.length === 0) {
-      source = defineProperty(source, key, {});
+      source = defineProperty(source, key, val);
       return;
     }
     if (!source?.hasOwnProperty('undefined')) {

--- a/aofl-js-packages/object-utils/modules/set.js
+++ b/aofl-js-packages/object-utils/modules/set.js
@@ -16,19 +16,20 @@ import {recurseObjectByPath} from './core';
  */
 const set = (obj, path, val) => {
   return recurseObjectByPath(obj, path, (key, pathParts, source, recurse) => {
-    if (key === '__proto__') {
-      return recurse(pathParts, source);
-    }
     if (pathParts.length === 0) {
-      source[key] = val;
+      source = defineProperty(source, key, {});
       return;
     }
-    if (typeof source[key] === 'undefined') {
-      source[key] = {};
+    if (!source?.hasOwnProperty('undefined')) {
+      source = defineProperty(source, key, {});
     }
     return recurse(pathParts, source[key]);
   });
 };
+
+function defineProperty(source, key, value) {
+  return Object.defineProperty(source, key, {value, configurable: true, writable: true, enumerable: true});
+}
 
 export {
   set

--- a/aofl-js-packages/object-utils/modules/set.js
+++ b/aofl-js-packages/object-utils/modules/set.js
@@ -16,6 +16,9 @@ import {recurseObjectByPath} from './core';
  */
 const set = (obj, path, val) => {
   return recurseObjectByPath(obj, path, (key, pathParts, source, recurse) => {
+    if (key === '__proto__') {
+      return recurse(pathParts, source);
+    }
     if (pathParts.length === 0) {
       source[key] = val;
       return;

--- a/aofl-js-packages/object-utils/test/set.spec.js
+++ b/aofl-js-packages/object-utils/test/set.spec.js
@@ -44,4 +44,10 @@ describe('object-utils#set', function() {
     expect(set(this.data, 'noprop.noprop.noprop', 'noprop'));
     expect(get(this.data, 'noprop.noprop.noprop')).to.equal('noprop');
   });
+
+  it('Should create __proto__ property, not pollute object prototype', function() {
+    set(this.data, '__proto__.another_property', 'test');
+    expect(get(this.data, '__proto__.another_property')).to.equal('test');
+    expect({}.another_property).to.be.undefined;
+  });
 });


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40aofl%2Fobject-utils

### ⚙️ Description *

with this fix, properties are defined safely, properties like `__proto__` will not link to the prototype

### 💻 Technical Description *

Using the `Object.defineProperty` in the `set` function, all keys will be used to define properties in the object and not the prototype

with this method keys like `__proto__`, `constructor`, etc can be used as normal properties of the object
![proto_property_console](https://user-images.githubusercontent.com/6598377/105868437-d8e2b480-5ffe-11eb-9628-fe21f98e1c17.png)


### 🐛 Proof of Concept (PoC) *


Use this sandbox: https://codesandbox.io/s/object-utils-prototype-pollution-qnxwg
Check the console:

```
Before: undefined
After: Prototype Polluted
```

### 🔥 Proof of Fix (PoF) *

![pollution_fix_console](https://user-images.githubusercontent.com/6598377/105855524-dbd6a880-5ff0-11eb-9565-388b8c56f4ce.png)

### 👍 User Acceptance Testing (UAT)

created unit test
manually tested a few scenarios
